### PR TITLE
feat: Add Hume AI TTS provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,22 @@ ELEVENLABS_API_KEY=your-elevenlabs-api-key-here
 # Cartesia API Key
 # Get your API key from: https://cartesia.ai/
 CARTESIA_API_KEY=your-cartesia-api-key-here
+
+# XTTS API Key (optional)
+# For self-hosted XTTS server, use 'none' or leave empty
+# For cloud services, add your API key
+XTTS_API_KEY=none
+
+# XTTS Server URL (optional)
+# Default: http://localhost:8020
+# XTTS_SERVER_URL=http://localhost:8020
+
+# Resemble AI API Key
+# Get your API key from: https://app.resemble.ai/
+# Navigate to Settings → API Keys
+RESEMBLE_API_KEY=your-resemble-api-key-here
+
+# Hume AI API Key
+# Get your API key from: https://platform.hume.ai/
+# Sign up → Create Project → Settings → API Keys
+HUME_API_KEY=your-hume-api-key-here

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saym",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saym",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.18.1",
@@ -32,6 +32,9 @@
         "ts-jest": "^29.1.1",
         "tsx": "^4.20.3",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ program
   .option('-v, --voice <voice>', 'Voice ID or name')
   .option('-f, --file <file>', 'Input text file')
   .option('-o, --output <file>', 'Output audio file')
-  .option('-p, --provider <provider>', 'TTS provider (elevenlabs, cartesia, xtts, resemble)')
+  .option('-p, --provider <provider>', 'TTS provider (elevenlabs, cartesia, xtts, resemble, hume)')
   .option('-l, --language <language>', 'Language code (e.g., ja, en, es)', 'en')
   .option('--format <format>', 'Audio format (mp3, wav, ogg)', 'mp3')
   .option('-s, --stream', 'Stream audio playback', false)
@@ -138,7 +138,7 @@ program
 program
   .command('voices')
   .description('List available voices for current provider (defaults to owned voices only)')
-  .option('-p, --provider <provider>', 'TTS provider (elevenlabs, cartesia, xtts, resemble)')
+  .option('-p, --provider <provider>', 'TTS provider (elevenlabs, cartesia, xtts, resemble, hume)')
   .option('-a, --all', 'Show all voices including public ones')
   .action(async (options) => {
     try {
@@ -153,7 +153,7 @@ program
       }
 
       console.log(`Current provider: ${currentProvider}`);
-      const defaultVoice = config.getDefaultVoice(currentProvider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble');
+      const defaultVoice = config.getDefaultVoice(currentProvider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume');
       if (defaultVoice) {
         console.log(`Default voice: ${defaultVoice}`);
       } else {
@@ -183,6 +183,9 @@ program
         } else if (providerType === 'resemble') {
           // For Resemble, filter to show only owned voices
           voices = allVoices.filter(voice => voice.labels?.is_owner === true);
+        } else if (providerType === 'hume') {
+          // For Hume, show all voices as they're all predefined
+          voices = allVoices;
         }
       }
 
@@ -234,16 +237,16 @@ configCommand
   .action((key, value) => {
     try {
       // Handle special cases for nested properties
-      if (key === 'ttsProvider' && !['elevenlabs', 'cartesia', 'xtts'].includes(value)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts');
+      if (key === 'ttsProvider' && !['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(value)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
       // Handle provider-specific default voice setting
       if (key.includes('DefaultVoice')) {
-        const match = key.match(/^(elevenlabs|cartesia|xtts)DefaultVoice$/);
+        const match = key.match(/^(elevenlabs|cartesia|xtts|resemble|hume)DefaultVoice$/);
         if (match) {
-          const provider = match[1] as 'elevenlabs' | 'cartesia' | 'xtts';
+          const provider = match[1] as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume';
           config.setProviderDefaultVoice(provider, value);
           console.log(`Configuration updated: ${provider} default voice = ${value}`);
           return;
@@ -261,11 +264,11 @@ configCommand
 // Simplified commands for common operations
 configCommand
   .command('provider <provider>')
-  .description('Set default TTS provider (elevenlabs|cartesia|xtts|resemble)')
+  .description('Set default TTS provider (elevenlabs|cartesia|xtts|resemble|hume)')
   .action((provider) => {
     try {
-      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
@@ -280,17 +283,17 @@ configCommand
 configCommand
   .command('voice <voice-id>')
   .description('Set default voice for current provider')
-  .option('-p, --provider <provider>', 'Set voice for specific provider (elevenlabs|cartesia|xtts|resemble)')
+  .option('-p, --provider <provider>', 'Set voice for specific provider (elevenlabs|cartesia|xtts|resemble|hume)')
   .action((voiceId, options) => {
     try {
       const provider = options.provider || config.get('ttsProvider') || 'elevenlabs';
       
-      if (options.provider && !['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(options.provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (options.provider && !['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(options.provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
-      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble', voiceId);
+      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume', voiceId);
       console.log(`Default voice for ${provider} set to: ${voiceId}`);
     } catch (error) {
       console.error('Error:', error);
@@ -301,15 +304,15 @@ configCommand
 // Keep the original detailed command for advanced users
 configCommand
   .command('set-default-voice <provider> <voice-id>')
-  .description('Set default voice for a specific provider (elevenlabs|cartesia|xtts|resemble)')
+  .description('Set default voice for a specific provider (elevenlabs|cartesia|xtts|resemble|hume)')
   .action((provider, voiceId) => {
     try {
-      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
-      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble', voiceId);
+      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume', voiceId);
       console.log(`Default voice for ${provider} set to: ${voiceId}`);
     } catch (error) {
       console.error('Error:', error);
@@ -331,16 +334,16 @@ configCommand
   .action((key, value) => {
     try {
       // Handle special cases for nested properties
-      if (key === 'ttsProvider' && !['elevenlabs', 'cartesia', 'xtts'].includes(value)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts');
+      if (key === 'ttsProvider' && !['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(value)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
       // Handle provider-specific default voice setting
       if (key.includes('DefaultVoice')) {
-        const match = key.match(/^(elevenlabs|cartesia|xtts)DefaultVoice$/);
+        const match = key.match(/^(elevenlabs|cartesia|xtts|resemble|hume)DefaultVoice$/);
         if (match) {
-          const provider = match[1] as 'elevenlabs' | 'cartesia' | 'xtts';
+          const provider = match[1] as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume';
           config.setProviderDefaultVoice(provider, value);
           console.log(`Configuration updated: ${provider} default voice = ${value}`);
           return;
@@ -358,11 +361,11 @@ configCommand
 // Simplified commands for common operations
 configCommand
   .command('provider <provider>')
-  .description('Set default TTS provider (elevenlabs|cartesia|xtts|resemble)')
+  .description('Set default TTS provider (elevenlabs|cartesia|xtts|resemble|hume)')
   .action((provider) => {
     try {
-      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
@@ -377,17 +380,17 @@ configCommand
 configCommand
   .command('voice <voice-id>')
   .description('Set default voice for current provider')
-  .option('-p, --provider <provider>', 'Set voice for specific provider (elevenlabs|cartesia|xtts|resemble)')
+  .option('-p, --provider <provider>', 'Set voice for specific provider (elevenlabs|cartesia|xtts|resemble|hume)')
   .action((voiceId, options) => {
     try {
       const provider = options.provider || config.get('ttsProvider') || 'elevenlabs';
       
-      if (options.provider && !['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(options.provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (options.provider && !['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(options.provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
-      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble', voiceId);
+      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume', voiceId);
       console.log(`Default voice for ${provider} set to: ${voiceId}`);
     } catch (error) {
       console.error('Error:', error);
@@ -398,15 +401,15 @@ configCommand
 // Keep the original detailed command for advanced users
 configCommand
   .command('set-default-voice <provider> <voice-id>')
-  .description('Set default voice for a specific provider (elevenlabs|cartesia|xtts|resemble)')
+  .description('Set default voice for a specific provider (elevenlabs|cartesia|xtts|resemble|hume)')
   .action((provider, voiceId) => {
     try {
-      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
-      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble', voiceId);
+      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume', voiceId);
       console.log(`Default voice for ${provider} set to: ${voiceId}`);
     } catch (error) {
       console.error('Error:', error);
@@ -438,7 +441,7 @@ program
 // Quick setup commands (top-level for ease of use)
 program
   .command('use [provider]')
-  .description('Switch to a provider (elevenlabs|cartesia|xtts|resemble) or show current provider')
+  .description('Switch to a provider (elevenlabs|cartesia|xtts|resemble|hume) or show current provider')
   .action((provider) => {
     try {
       if (!provider) {
@@ -446,7 +449,7 @@ program
         const currentProvider = config.get('ttsProvider') || 'elevenlabs';
         console.log(`Current provider: ${currentProvider}`);
         
-        const defaultVoice = config.getDefaultVoice(currentProvider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble');
+        const defaultVoice = config.getDefaultVoice(currentProvider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume');
         if (defaultVoice) {
           console.log(`Default voice for ${currentProvider}: ${defaultVoice}`);
         } else {
@@ -455,8 +458,8 @@ program
         return;
       }
       
-      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (!['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
@@ -464,7 +467,7 @@ program
       console.log(`Now using ${provider} as default provider`);
       
       // Show current default voice for this provider if any
-      const defaultVoice = config.getDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble');
+      const defaultVoice = config.getDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume');
       if (defaultVoice) {
         console.log(`Default voice for ${provider}: ${defaultVoice}`);
       } else {
@@ -484,12 +487,12 @@ program
     try {
       const provider = options.provider || config.get('ttsProvider') || 'elevenlabs';
       
-      if (options.provider && !['elevenlabs', 'cartesia', 'xtts', 'resemble'].includes(options.provider)) {
-        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble');
+      if (options.provider && !['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'].includes(options.provider)) {
+        console.error('Error: Invalid provider. Choose from: elevenlabs, cartesia, xtts, resemble, hume');
         process.exit(1);
       }
       
-      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble', voiceId);
+      config.setProviderDefaultVoice(provider as 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume', voiceId);
       console.log(`✅ Default voice for ${provider} set to: ${voiceId}`);
     } catch (error) {
       console.error('Error:', error);

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,7 +96,7 @@ export class ConfigManager {
   /**
    * Get API key from environment or config
    */
-  getApiKey(provider?: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble'): string | undefined {
+  getApiKey(provider?: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume'): string | undefined {
     const ttsProvider = provider || this.config.ttsProvider || 'elevenlabs';
     
     switch (ttsProvider) {
@@ -108,6 +108,8 @@ export class ConfigManager {
         return process.env.XTTS_API_KEY || this.config.providers?.xtts?.apiKey || 'none';
       case 'resemble':
         return process.env.RESEMBLE_API_KEY || this.config.providers?.resemble?.apiKey;
+      case 'hume':
+        return process.env.HUME_API_KEY || this.config.providers?.hume?.apiKey;
       default:
         return undefined;
     }
@@ -116,7 +118,7 @@ export class ConfigManager {
   /**
    * Get default voice for a specific provider
    */
-  getDefaultVoice(provider?: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble'): string | undefined {
+  getDefaultVoice(provider?: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume'): string | undefined {
     const ttsProvider = provider || this.config.ttsProvider || 'elevenlabs';
     
     // First check provider-specific default voice
@@ -141,8 +143,13 @@ export class ConfigManager {
           return this.config.providers.resemble.defaultVoice;
         }
         break;
+      case 'hume':
+        if (this.config.providers?.hume?.defaultVoice) {
+          return this.config.providers.hume.defaultVoice;
+        }
+        break;
     }
-    
+
     // Fallback to global default voice
     return this.config.defaultVoice;
   }
@@ -150,7 +157,7 @@ export class ConfigManager {
   /**
    * Set default voice for a specific provider
    */
-  setProviderDefaultVoice(provider: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble', voiceId: string): void {
+  setProviderDefaultVoice(provider: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume', voiceId: string): void {
     if (!this.config.providers) {
       this.config.providers = {};
     }

--- a/src/providers/hume-provider.ts
+++ b/src/providers/hume-provider.ts
@@ -1,0 +1,217 @@
+import axios, { AxiosInstance } from 'axios';
+import { Readable } from 'stream';
+import {
+  TTSProvider,
+  TTSProviderConfig,
+  TTSOptions,
+  TTSVoice,
+  TTSProviderError
+} from './tts-provider';
+
+export class HumeProvider implements TTSProvider {
+  readonly name = 'hume';
+  private client!: AxiosInstance;
+  private apiKey!: string;
+  private baseUrl = 'https://api.hume.ai/v0';
+
+  async initialize(config: TTSProviderConfig): Promise<void> {
+    if (!config.apiKey) {
+      throw new TTSProviderError(this.name, 'API key is required');
+    }
+
+    this.apiKey = config.apiKey;
+    this.client = axios.create({
+      baseURL: this.baseUrl,
+      headers: {
+        'X-Hume-Api-Key': this.apiKey,
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  async textToSpeech(text: string, voiceId: string, options?: TTSOptions): Promise<Buffer> {
+    try {
+      const requestBody: any = {
+        utterances: [
+          {
+            text,
+          }
+        ],
+        format: {
+          type: options?.outputFormat || 'mp3'
+        }
+      };
+
+      // Use the voice ID from Hume API
+      requestBody.utterances[0].voice = {
+        id: voiceId
+      };
+
+      const response = await this.client.post(
+        '/tts/file',
+        requestBody,
+        {
+          responseType: 'arraybuffer',
+        }
+      );
+
+      return Buffer.from(response.data);
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        const message = error.response?.data?.message || error.message;
+
+        if (status === 401) {
+          throw new TTSProviderError(this.name, 'Invalid API key');
+        } else if (status === 429) {
+          throw new TTSProviderError(this.name, 'Rate limit exceeded');
+        } else if (status === 400) {
+          throw new TTSProviderError(this.name, `Bad request: ${message}`);
+        } else {
+          throw new TTSProviderError(this.name, `API error: ${message}`);
+        }
+      }
+      throw new TTSProviderError(this.name, 'Failed to synthesize speech');
+    }
+  }
+
+  async textToSpeechStream(text: string, voiceId: string, options?: TTSOptions): Promise<Readable> {
+    try {
+      const requestBody: any = {
+        utterances: [
+          {
+            text,
+          }
+        ],
+        format: {
+          type: options?.outputFormat || 'mp3'
+        }
+      };
+
+      // Use the voice ID from Hume API
+      requestBody.utterances[0].voice = {
+        id: voiceId
+      };
+
+      const response = await this.client.post(
+        '/tts/file/streaming',
+        requestBody,
+        {
+          responseType: 'stream',
+        }
+      );
+
+      return response.data as Readable;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        const message = error.response?.data?.message || error.message;
+
+        if (status === 401) {
+          throw new TTSProviderError(this.name, 'Invalid API key');
+        } else if (status === 429) {
+          throw new TTSProviderError(this.name, 'Rate limit exceeded');
+        } else if (status === 400) {
+          throw new TTSProviderError(this.name, `Bad request: ${message}`);
+        } else {
+          throw new TTSProviderError(this.name, `API error: ${message}`);
+        }
+      }
+      throw new TTSProviderError(this.name, 'Failed to stream speech');
+    }
+  }
+
+  async listVoices(): Promise<TTSVoice[]> {
+    try {
+      const voices: TTSVoice[] = [];
+
+      // Fetch HUME_AI preset voices
+      const humeResponse = await this.client.get('/tts/voices', {
+        params: {
+          provider: 'HUME_AI',
+          page_size: 100
+        }
+      });
+
+      if (humeResponse.data?.voices_page) {
+        for (const voice of humeResponse.data.voices_page) {
+          voices.push({
+            id: voice.id,
+            name: voice.name,
+            provider: 'hume',
+            description: `Hume AI preset voice: ${voice.name}`,
+            languages: ['en', 'ja'], // Hume AI supports multiple languages
+          });
+        }
+      }
+
+      // Fetch CUSTOM_VOICE voices
+      try {
+        const customResponse = await this.client.get('/tts/voices', {
+          params: {
+            provider: 'CUSTOM_VOICE',
+            page_size: 100
+          }
+        });
+
+        if (customResponse.data?.voices_page) {
+          for (const voice of customResponse.data.voices_page) {
+            voices.push({
+              id: voice.id,
+              name: voice.name,
+              provider: 'hume',
+              description: `Custom voice: ${voice.name}`,
+              languages: ['en', 'ja'], // Custom voices may support multiple languages
+              labels: { is_owner: true, category: 'custom' }
+            });
+          }
+        }
+      } catch (error) {
+        // Custom voices might not be available or accessible, continue with preset voices
+      }
+
+      return voices;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        const message = error.response?.data?.message || error.message;
+
+        if (status === 401) {
+          throw new TTSProviderError(this.name, 'Invalid API key for voice listing');
+        } else if (status === 429) {
+          throw new TTSProviderError(this.name, 'Rate limit exceeded for voice listing');
+        } else if (status === 400) {
+          throw new TTSProviderError(this.name, `Bad request: ${message}`);
+        } else {
+          throw new TTSProviderError(this.name, `API error: ${message}`);
+        }
+      }
+      throw new TTSProviderError(this.name, 'Failed to fetch voices from Hume API');
+    }
+  }
+
+  async getVoice(voiceId: string): Promise<TTSVoice | null> {
+    const voices = await this.listVoices();
+    return voices.find(v => v.id === voiceId) || null;
+  }
+
+  getSupportedFormats(): string[] {
+    return ['mp3', 'wav', 'ogg', 'flac'];
+  }
+
+  async validateConnection(): Promise<boolean> {
+    try {
+      // Make a simple test request to validate the API key
+      await this.client.post('/tts/file', {
+        utterances: [{ text: 'test' }],
+        format: { type: 'mp3' }
+      }, {
+        validateStatus: (status) => status === 200 || status === 401
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+}

--- a/src/providers/provider-factory.ts
+++ b/src/providers/provider-factory.ts
@@ -3,8 +3,9 @@ import { ElevenLabsProvider } from './elevenlabs-provider';
 import { CartesiaProvider } from './cartesia-provider';
 import { XTTSProvider } from './xtts-provider';
 import { ResembleProvider } from './resemble-provider';
+import { HumeProvider } from './hume-provider';
 
-export type ProviderType = 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble';
+export type ProviderType = 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume';
 
 export class ProviderFactory {
   private static providers: Map<string, TTSProvider> = new Map();
@@ -31,6 +32,9 @@ export class ProviderFactory {
       case 'resemble':
         provider = new ResembleProvider();
         break;
+      case 'hume':
+        provider = new HumeProvider();
+        break;
       default:
         throw new Error(`Unknown provider type: ${type}`);
     }
@@ -50,6 +54,6 @@ export class ProviderFactory {
   }
 
   static getSupportedProviders(): ProviderType[] {
-    return ['elevenlabs', 'cartesia', 'xtts', 'resemble'];
+    return ['elevenlabs', 'cartesia', 'xtts', 'resemble', 'hume'];
   }
 }

--- a/src/providers/tts-provider.ts
+++ b/src/providers/tts-provider.ts
@@ -9,6 +9,7 @@ export interface TTSOptions {
   outputFormat?: string;
   modelId?: string;
   language?: string;
+  voiceDescription?: string;
 }
 
 export interface TTSVoice {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export interface Config {
   defaultVoice?: string;
   defaultLanguage?: string;
   outputFormat?: 'mp3' | 'wav' | 'ogg';
-  ttsProvider?: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble';
+  ttsProvider?: 'elevenlabs' | 'cartesia' | 'xtts' | 'resemble' | 'hume';
   providers?: {
     elevenlabs?: {
       apiKey?: string;
@@ -18,6 +18,10 @@ export interface Config {
       defaultVoice?: string;
     };
     resemble?: {
+      apiKey?: string;
+      defaultVoice?: string;
+    };
+    hume?: {
       apiKey?: string;
       defaultVoice?: string;
     };


### PR DESCRIPTION
## Summary
- Add comprehensive Hume AI TTS provider integration to saym
- Enable real-time voice listing via Hume AI Voices API
- Support both preset and custom voices from Hume AI platform
- Extend CLI functionality to include Hume provider in all commands

## Key Features
- **New HumeProvider class** with full TTS and streaming capabilities
- **Real-time voice discovery** via `/tts/voices` API endpoint
- **Multi-provider voice support** (HUME_AI preset + CUSTOM_VOICE)
- **Comprehensive CLI integration** across all saym commands
- **Configuration management** for Hume API keys and default voices
- **Environment template** updated with Hume AI API key setup

## Technical Changes
- Created `src/providers/hume-provider.ts` with complete TTS implementation
- Updated `ProviderFactory` to include Hume provider
- Extended `TTSOptions` interface with `voiceDescription` parameter
- Updated all CLI commands to support 'hume' provider option
- Enhanced `ConfigManager` for Hume API key and voice management
- Updated TypeScript type definitions throughout the codebase

## Test plan
- [x] Build passes without TypeScript errors
- [x] Linting passes without issues
- [x] Provider factory correctly instantiates Hume provider
- [x] CLI commands accept 'hume' as valid provider option
- [x] Voice listing works with mock API responses
- [x] Configuration system properly handles Hume settings
- [ ] Integration test with actual Hume API key
- [ ] End-to-end TTS generation with Hume voices

🤖 Generated with [Claude Code](https://claude.ai/code)